### PR TITLE
Fix template deployment.yaml resources

### DIFF
--- a/charts/extended-ceph-exporter/Chart.yaml
+++ b/charts/extended-ceph-exporter/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.4.1
+version: 1.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/extended-ceph-exporter/README.md
+++ b/charts/extended-ceph-exporter/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart for deploying the extended-ceph-exporter to Kubernetes
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.3.0](https://img.shields.io/badge/AppVersion-v1.3.0-informational?style=flat-square)
 
 ## Get Repo Info
 

--- a/charts/extended-ceph-exporter/templates/deployment.yaml
+++ b/charts/extended-ceph-exporter/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               port: http-metrics
           {{- with .Values.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.volumeMounts }}
           volumeMounts:


### PR DESCRIPTION
The current deployment.yaml has temlated resources using `with` which changes the context. Inside the new context `.Values.resources` is used, which doesn't exist in that context, causing the chart to fail.
volumeMounts for example is templated correctly.