### PR TITLE
Only use envFrom in Deployment if the postInstallJob is enabled

### DIFF
--- a/charts/extended-ceph-exporter/templates/deployment.yaml
+++ b/charts/extended-ceph-exporter/templates/deployment.yaml
@@ -37,9 +37,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.postInstallJob.enabled }}
           envFrom:
             - secretRef:
                 name: {{ include "extended-ceph-exporter.fullname" . }}-env
+          {{- end }}
           {{- with .Values.additionalEnv }}
           env:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
The issue is described [here](https://github.com/galexrt/extended-ceph-exporter/issues/39#issuecomment-3338707077). This is fixing it